### PR TITLE
Merge "alpine" into master

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ Something like plugin manager for kornshell
 * git (avoid apple crappy one, install one from nix or brew[^1])
 * ksh93 ([Best option](https://github.com/ksh93/ksh)), pdksh or mksh(with limitations[^2]).
 * printf built-in to shell, or as external program
-* tput(should be built-in as well[^3])
 
 ## Tested OSes
 
@@ -33,7 +32,7 @@ Something like plugin manager for kornshell
 
 3. Only [ksh93u+m](https://github.com/ksh93/ksh) supports autocd, so note that.
 
-4. Some systems may require setting `export ENV=$HOME/.kshrc`[^4] in ~/.profile or /etc/profile(don't forget to reboot).
+4. Some systems may require setting `export ENV=$HOME/.kshrc`[^3] in ~/.profile or /etc/profile(don't forget to reboot).
 
 Also mksh use .mkshrc, so you either rename .kshrc to .mkshrc, or use step above
 
@@ -77,6 +76,4 @@ Type: `korn rm` or `korn remove`
 
 [^2]: As I tested it on NetBSD, there were problems with prompt loading if there were too many lines in PS1 variable. It cannot be fixed from this level most likely. 
 
-[^3]: If it's not,(like on termux on android) try installing `coreutils`.
-
-[^4]: You can set any path(and copy .kshrc there), for example i have it under `export ENV="$HOME/.config/ksh/rc"`
+[^3]: You can set any path(and copy .kshrc there), for example i have it under `export ENV="$HOME/.config/ksh/rc"`

--- a/bin/install.ksh
+++ b/bin/install.ksh
@@ -16,11 +16,10 @@ do
 done
 }
 requirements() {
-! { type ksh || type ksh93; } && echo "No Korn Shell installed" && exit 127
+! { type ksh || type ksh93 || type oksh || type mksh; } && echo "No Korn Shell installed" && exit 127
 ! type sed && echo "No sed installed" && exit 127
 ! type git && echo "Script needs git to clone repository" && exit 127
 ! type printf && echo "Printf is needed" && exit 127
-! type tput && echo "No tput detected" && exit 127
 }
 preinstall() {
 [[ -f ~/.kshrc ]] && mv ~/.kshrc ~/.kshrc_bak && echo "You have .kshrc in your, home, renaming it to .kshrc_bak, remember to copy your data to new .kshrc"

--- a/bin/korn
+++ b/bin/korn
@@ -1,4 +1,3 @@
-#!/usr/bin/env ksh
 usage(){
     printf "Usage: korn [command]\n"
     printf "commands: update, remove, scribble(c debbuging)\n"

--- a/docs/BUILT_FUNCTIONS.md
+++ b/docs/BUILT_FUNCTIONS.md
@@ -6,11 +6,11 @@ This file has list of functions and variables built in korny, to use when creati
 * **\_git\_check_changes** - checks if there are changes to repository.
 * **\_git\_prompt** - Both of the above functions combined, used for prompts(not in broadchurch)
 
-## \_colors_prompt.ksh
+## \_colors\_prompt.ksh
 
 * **multiline** - function for disabling multiline for two or more line prompts.
 * **\_ls\_colors** - setting colors for ls command. It takes either 0 or 2 arguments. Pass two arguments and it will use them as custom ls colors. Those arguments need to be in specific format.
-* **\_ext\_ascii** - used for printing extended ascii characters.
+* **\_blink** - after that characters will blink until $RESET
 * **custom\_color** - function for defining one of custom_colors(from 8 up to number 255). Google 255 shell colours to see their look.
 Run by `custom_color light_brown 94` Access by `${cfg[light_brown]}` and `${cfb[light_brown]}`
 * **load_colors** - function used only on startup, should not be used. Access colors by `${fg[black]}` and ${bg[black]}

--- a/plugs/_aliases.ksh
+++ b/plugs/_aliases.ksh
@@ -3,8 +3,8 @@ set -o emacs
 alias __H='echo "\001"'     # home = ^a = start of line
 alias __Y='echo "\005"'     # end = ^e = end of line
 alias ..='cd ..'
-alias ls='ls -GF'
-alias l='ls -Gla'
+#alias ls='ls -GF'
+#alias l='ls -Gla'
 [[ $(uname) == "SunOS" ]] \
 	&& alias whoami='print $LOGNAME' \
 	&& alias ls="ls --color"

--- a/plugs/_colors_prompt.ksh
+++ b/plugs/_colors_prompt.ksh
@@ -1,14 +1,6 @@
 set -A fg bg cfg cbg
-export cap_setfg=setaf 
-export cap_setbg=setab
-case $(uname) in
-FreeBSD)
-        cap_setfg=AF
-        cap_setbg=AB
-        ;;
-esac
 _multiline(){
-    if [[ $(set -o | grep multiline) == *"multiline"* ]]; then
+    if [[ $(set -o | grep multiline) = *"multiline"* ]]; then
         set +o multiline
     fi
 }
@@ -28,30 +20,27 @@ _ls_colors(){
         fi
     fi
 }
-_ext_ascii()
+_blink()
 {
-    tput as 2> /dev/null
-    if [[ $? == 0 ]]; then
-        printf "$1"
-        tput ae
-    fi
+    printf "\033[5m"
 }
 custom_color()
 {
         export "$1"="$2"
-        cfg[$2]="$(tput $cap_setfg "$2" "$2" "$2")"
-        cbg[$2]="$(tput $cap_setbg "$2" "$2" "$2")"
+        cfg[$2]="$(printf '\033[38;5;%dm' "$2")"
+        cbg[$2]="$(printf '\033[48;5;%dm' "$2")"
+
 }
 load_colors()
 {
         export black=0 red=1 green=2 brown=3 blue=4 magenta=5 cyan=6 white=7 RESET
         RESET="$(printf '\033[0;10m')"
-        BOLD="$(tput bold)"
+        BOLD="$(printf '\033[1m')"
         integer i=0
         while (( i < 8 ))
         do 
-                fg[$i]="$(tput $cap_setfg "$i" "$i" "$i")"
-                bg[$i]="$(tput $cap_setbg "$i" "$i" "$i")"
+                fg[$i]="$(printf '\033[3%dm' "$i")"
+                bg[$i]="$(printf '\033[4%dm' "$i")"
                 (( i=i+1 ))
         done
 }

--- a/prompts/broadchurch.ksh
+++ b/prompts/broadchurch.ksh
@@ -1,9 +1,9 @@
 _multiline #If multiline option exists, turn it off.
-PS1='$(_ext_ascii lq)$BOLD${fg[blue]}[$RESET'
+PS1='$BOLD${fg[blue]}[$RESET'
 PS1="$PS1"'${fg[magenta]}$(whoami)$RESET@${fg[magenta]}$(hostname -s)$RESET'
 PS1="$PS1"'$BOLD${fg[blue]}]$RESET:${fg[cyan]}$(_print_pwd)$RESET '
-PS1="$PS1"'${fg[red]}$(tput blink)$(_git_check_changes)$RESET'
+PS1="$PS1"'${fg[red]}$(_blink)$(_git_check_changes)$RESET'
 PS1="$PS1"'${fg[red]}$(_git_branch)$RESET
 '
-PS1="$PS1"'$(_ext_ascii mq)>$RESET '
+PS1="$PS1"'->$RESET '
 _ls_colors

--- a/prompts/ibsd.ksh
+++ b/prompts/ibsd.ksh
@@ -6,7 +6,7 @@ custom_color c_red 196
 custom_color c_blue 27
 custom_color c_green 40
 PLUG_WARN='Load android plugin in order to use this prompt'
-#tput bold prints bold characters, it's stopped however by $RESET
+#bold prints bold characters, it's stopped however by $RESET
 PS1='$BOLD${cfg[light_brown]}[$(_print_short_pwd)]$RESET '
 PS1="$PS1"'${cfg[c_red]}$(_git_prompt)$RESET'
 PS1="$PS1"'${cfg[c_green]}$(_adb_rdy)$RESET'


### PR DESCRIPTION
* Removed tput as dependency
* Removed all tput usage and replaced it with printf escape characters.
* Removed ls --color aliases.
* Modified install script to work when only mksh or oksh are installed
* Broadchurch is simplified to only use ascii, at least for now.
* removed #!/usr/bin/env ksh from korn, as mksh, oksh, ksh93 would not work.